### PR TITLE
feat: add deleteExecution node

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -34,6 +34,7 @@ import { License } from '@/License';
 import { EventsService } from '@/services/events.service';
 import { NodeTypes } from '@/NodeTypes';
 import { Telemetry } from '@/telemetry';
+import { ExecutionRepository } from '@db/repositories/execution.repository';
 
 function userToPayload(user: User): {
 	userId: string;
@@ -58,6 +59,7 @@ export class InternalHooks {
 		private readonly nodeTypes: NodeTypes,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly workflowRepository: WorkflowRepository,
+		private readonly executionRepository: ExecutionRepository,
 		eventsService: EventsService,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly eventBus: MessageEventBus,
@@ -500,6 +502,10 @@ export class InternalHooks {
 						},
 				  }),
 		);
+
+		if (telemetryProperties.success && runData.data.resultData.deleteExecution) {
+			promises.push(this.executionRepository.delete(executionId));
+		}
 
 		void Promise.all([...promises, this.telemetry.trackWorkflowExecution(telemetryProperties)]);
 	}

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -503,7 +503,7 @@ export class InternalHooks {
 				  }),
 		);
 
-		if (telemetryProperties.success && runData.data.resultData.deleteExecution) {
+		if (telemetryProperties.success && runData?.data.resultData.deleteExecution) {
 			promises.push(this.executionRepository.delete(executionId));
 		}
 

--- a/packages/cli/test/unit/InternalHooks.test.ts
+++ b/packages/cli/test/unit/InternalHooks.test.ts
@@ -24,6 +24,7 @@ describe('InternalHooks', () => {
 		mock(),
 		mock(),
 		mock(),
+		mock(),
 		license,
 	);
 

--- a/packages/core/src/ExecutionMetadata.ts
+++ b/packages/core/src/ExecutionMetadata.ts
@@ -72,3 +72,10 @@ export function getWorkflowExecutionMetadata(
 ): string {
 	return getAllWorkflowExecutionMetadata(executionData)[String(key).slice(0, 50)];
 }
+
+export function setWorkflowDeleteExecution(
+	executionData: IRunExecutionData,
+	isDelete: boolean,
+): void {
+	executionData.resultData.deleteExecution = isDelete;
+}

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -142,6 +142,7 @@ import {
 	getWorkflowExecutionMetadata,
 	setAllWorkflowExecutionMetadata,
 	setWorkflowExecutionMetadata,
+	setWorkflowDeleteExecution,
 } from './ExecutionMetadata';
 import { getSecretsProxy } from './Secrets';
 import Container from 'typedi';
@@ -1911,6 +1912,9 @@ export function getAdditionalKeys(
 						},
 						getAll(): Record<string, string> {
 							return getAllWorkflowExecutionMetadata(runExecutionData);
+						},
+						setDeleteExecution(isDelete: boolean): void {
+							setWorkflowDeleteExecution(runExecutionData, isDelete);
 						},
 				  }
 				: undefined,

--- a/packages/nodes-base/nodes/DeleteExecution/DeleteExecution.node.json
+++ b/packages/nodes-base/nodes/DeleteExecution/DeleteExecution.node.json
@@ -1,0 +1,16 @@
+{
+	"node": "n8n-nodes-base.deleteExecution",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Development", "Core Nodes"],
+	"subcategories": {
+		"Core Nodes": ["Helpers"]
+	},
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executiondata/"
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/DeleteExecution/DeleteExecution.node.ts
+++ b/packages/nodes-base/nodes/DeleteExecution/DeleteExecution.node.ts
@@ -1,0 +1,31 @@
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+export class DeleteExecution implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Delete Execution',
+		name: 'deleteExecution',
+		icon: 'fa:trash',
+		group: ['organization'],
+		version: 1,
+		description: 'Delete Execution',
+		defaults: {
+			name: 'Delete workflow execution record',
+			color: '#b0b0b0',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const context = this.getWorkflowDataProxy(0);
+		context.$execution.customData.setDeleteExecution(true);
+		return [items];
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -464,6 +464,7 @@
       "dist/nodes/DateTime/DateTime.node.js",
       "dist/nodes/DebugHelper/DebugHelper.node.js",
       "dist/nodes/DeepL/DeepL.node.js",
+      "dist/nodes/DeleteExecution/DeleteExecution.node.js",
       "dist/nodes/Demio/Demio.node.js",
       "dist/nodes/Dhl/Dhl.node.js",
       "dist/nodes/Discord/Discord.node.js",

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1891,7 +1891,7 @@ export interface IRunExecutionData {
 		pinData?: IPinData;
 		lastNodeExecuted?: string;
 		metadata?: Record<string, string>;
-		deleteExecution?: boolean;
+		deleteExecution?: boolean | null;
 	};
 	executionData?: {
 		contextData: IExecuteContextData;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1891,6 +1891,7 @@ export interface IRunExecutionData {
 		pinData?: IPinData;
 		lastNodeExecuted?: string;
 		metadata?: Record<string, string>;
+		deleteExecution?: boolean;
 	};
 	executionData?: {
 		contextData: IExecuteContextData;


### PR DESCRIPTION
## Summary

add a new node: deleteExecution.
when deleteExecution node is executed, you will not see the execution record.

1. add a new Node deleteExecution, which will save a `deleteExecution` flag in process data when it is executed.
2. when the process is finished, check the deleteExecution flag. delete the execution record if `deleteExectuion = true`.


## Related tickets and issues



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 